### PR TITLE
fix protected/encrypted attributes

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -118,14 +118,14 @@
             {
                 "admin": ">=7.4.10"
             }
-        ],
-        "protectedNative": [
-            "password"
-        ],
-        "encryptedNative": [
-            "password"
         ]
     },
+    "protectedNative": [
+        "password"
+    ],
+    "encryptedNative": [
+        "password"
+    ],
     "native": {
         "email": "",
         "password": "",


### PR DESCRIPTION
This PR should fix 

👀 [W173] Potential sensitive data "password" not listed at "protectedNative" in [io-package.json](https://github.com/raspilaurent/ioBroker.acinfinity/blob/master/io-package.json)

👀 [W174] Potential sensitive data "password" not listed at "encryptedNative" in [io-package.json](https://github.com/raspilaurent/ioBroker.acinfinity/blob/master/io-package.json)

Attributes `protectedNative` and `encryptedNative` are toplevel attributes and not elements of common tree.
Please see schema for details.

NOTE: due to linter conflicts I cannot test this correction at my fork. So please feel free to contact me again if still problems exist after merging